### PR TITLE
Fixing the Movie property name

### DIFF
--- a/MVCMovie/Data/MVCMovieContext.cs
+++ b/MVCMovie/Data/MVCMovieContext.cs
@@ -13,6 +13,6 @@ namespace MVCMovie.Data
         {
         }
 
-        public DbSet<MvcMovie.Models.Movie> Movie { get; set; } = default!;
+        public DbSet<Movie> Movies { get; set; } = default!;
     }
 }


### PR DESCRIPTION
I have changed the Movie property name to Movies because this property represents a collection of Movie entities in the database. This is actually the suggested naming convention for entities. 

You don't need to put the full path for the object type

I suggest you too to use "dotnet new gitignore" command in Powershell in where your project is located to create a ".gitignore" file alongside with your project to ignore pushing unwanted files to github. Do it before you start using git.

Good Luck :)